### PR TITLE
Changes for CUDA-12 compatability.

### DIFF
--- a/src/dedisp.cu
+++ b/src/dedisp.cu
@@ -418,7 +418,7 @@ dedisp_size dedisp_get_dm_delay(const dedisp_plan plan, int dm_trial) {
   if (0 == plan->dm_count) {
     throw_getter_error(DEDISP_NO_DM_LIST_SET, 0);
   }
-  if (dm_trial < 0 || dm_trial >= plan->dm_count) {
+  if (dm_trial < 0 || dm_trial >= int(plan->dm_count)) {
     throw_getter_error(DEDISP_UNKNOWN_ERROR, 0);
   }
   return (plan->dm_list[dm_trial] * plan->delay_table[plan->nchans - 1] + 0.5);


### PR DESCRIPTION
This should allow DEDISP to compile with CUDA 12+ by switching off the old texture routines.

Description of the fix is provided here:
https://sourceforge.net/p/heimdall-astro/discussion/general/thread/241bed6025/

~ Joe G.